### PR TITLE
Disable Expect100Continue on request object

### DIFF
--- a/EdgeGridAuth/EdgeGridV1Signer.cs
+++ b/EdgeGridAuth/EdgeGridV1Signer.cs
@@ -244,6 +244,8 @@ namespace Akamai.EdgeGrid.Auth
             {
                 //Disable the nastiness of Expect100Continue
                 ServicePointManager.Expect100Continue = false;
+                //Also disable it on request object !
+                ((HttpWebRequest)request).ServicePoint.Expect100Continue = false;
                 if (uploadStream == null)
                     request.ContentLength = 0;
                 else if (uploadStream.CanSeek)


### PR DESCRIPTION
Hi,

We found some issue on the library when using it.

The first POST request goes OK to the server, then the next ones are KO and we receive from Akamai servers the following response : 

Unexpected Response from Server: ExpectationFailed Expectation Failed
Connection: close
Content-Length: 444
Content-Type: application/problem+json
Date: Fri, 19 Jun 2015 09:03:49 GMT

{
  "type": "https://problems.purge.akamaiapis.net/-/pep-authn/policy-error",
  "title": "Expectation Failed",
  "status": 417,
  "detail": "Expect 100-continue header is not supported",
  "instance": "https://purge.akamaiapis.net/ccu/v2/queues/default",
  "method": "POST",
  "serverIp": "",
  "clientIp": "",
  "requestId": "8f4f3c4",
  "requestTime": "2015-06-19T09:03:49Z"
}

This update corrects the problem for us !
