### PR TITLE
/DXISSUE-46: Update readme

### DIFF
--- a/EdgeGridAuth/ClientCredential.cs
+++ b/EdgeGridAuth/ClientCredential.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Akamai Technologies http://developer.akamai.com.
+﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
 //
 // Licensed under the Apache License, KitVersion 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Author: colinb@akamai.com  (Colin Bendell)
 //
 
 using System;

--- a/EdgeGridAuth/ClientCredential.cs
+++ b/EdgeGridAuth/ClientCredential.cs
@@ -1,20 +1,4 @@
-﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
-//
-// Licensed under the Apache License, KitVersion 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-//
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/EdgeGridAuth/EdgeGridV1Signer.cs
+++ b/EdgeGridAuth/EdgeGridV1Signer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Akamai Technologies http://developer.akamai.com.
+﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
 //
 // Licensed under the Apache License, KitVersion 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Author: colinb@akamai.com  (Colin Bendell)
 //
 using Akamai.Utils;
 using System;
@@ -42,7 +41,6 @@ namespace Akamai.EdgeGrid.Auth
     /// TODO: support multiplexing 
     /// TODO: optimize and adapt throughput based on connection latency
     /// 
-    /// Author: colinb@akamai.com  (Colin Bendell)
     /// </summary>
     public class EdgeGridV1Signer: IRequestSigner
     {

--- a/EdgeGridAuth/EdgeGridV1Signer.cs
+++ b/EdgeGridAuth/EdgeGridV1Signer.cs
@@ -1,19 +1,4 @@
-﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
-//
-// Licensed under the Apache License, KitVersion 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-//
-using Akamai.Utils;
+﻿using Akamai.Utils;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;

--- a/EdgeGridAuth/IRequestSigner.cs
+++ b/EdgeGridAuth/IRequestSigner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Akamai Technologies http://developer.akamai.com.
+﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
 //
 // Licensed under the Apache License, KitVersion 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Author: colinb@akamai.com  (Colin Bendell)
 //
 
 using System;
@@ -27,8 +26,7 @@ namespace Akamai.EdgeGrid.Auth
 {
     /// <summary>
     /// Interface describing a request signer that signs service requests.
-    /// 
-    /// Author: colinb@akamai.com  (Colin Bendell)
+    ///
     /// </summary>
     interface IRequestSigner
     {

--- a/EdgeGridAuth/IRequestSigner.cs
+++ b/EdgeGridAuth/IRequestSigner.cs
@@ -1,20 +1,4 @@
-﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
-//
-// Licensed under the Apache License, KitVersion 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-//
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/EdgeGridAuth/Properties/AssemblyInfo.cs
+++ b/EdgeGridAuth/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Akamai.EdgeGrid.Auth")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyCopyright("Copyright ©  2024")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/EdgeGridAuth/Utils.cs
+++ b/EdgeGridAuth/Utils.cs
@@ -1,20 +1,4 @@
-﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
-//
-// Licensed under the Apache License, KitVersion 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-//
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.IO;

--- a/EdgeGridAuth/Utils.cs
+++ b/EdgeGridAuth/Utils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Akamai Technologies http://developer.akamai.com.
+﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
 //
 // Licensed under the Apache License, KitVersion 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Author: colinb@akamai.com  (Colin Bendell)
 //
 
 using System;
@@ -47,8 +46,7 @@ namespace Akamai.Utils
     /// General utility functions needed to implement the NetStorageKit.  Many of these functions are also
     /// available as standard parts of other libraries, but this package strives to operate without any
     /// external dependencies.
-    /// 
-    /// Author: colinb@akamai.com  (Colin Bendell)
+    ///
     /// </summary>
     public static class ExtensionMethods
     {

--- a/EdgeGridAuthTest/ClientCredentialTest.cs
+++ b/EdgeGridAuthTest/ClientCredentialTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Akamai Technologies http://developer.akamai.com.
+﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Author: colinb@akamai.com  (Colin Bendell)
 //
 
 using System;

--- a/EdgeGridAuthTest/ClientCredentialTest.cs
+++ b/EdgeGridAuthTest/ClientCredentialTest.cs
@@ -1,20 +1,4 @@
-﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-//
-
-using System;
+﻿using System;
 using Akamai.Utils;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;

--- a/EdgeGridAuthTest/EdgeGridV1SignerTest.cs
+++ b/EdgeGridAuthTest/EdgeGridV1SignerTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Akamai Technologies http://developer.akamai.com.
+﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
 //
 // Licensed under the Apache License, KitVersion 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Author: colinb@akamai.com  (Colin Bendell)
 //
 using System;
 using Akamai.Utils;

--- a/EdgeGridAuthTest/EdgeGridV1SignerTest.cs
+++ b/EdgeGridAuthTest/EdgeGridV1SignerTest.cs
@@ -1,19 +1,4 @@
-﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
-//
-// Licensed under the Apache License, KitVersion 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-//
-using System;
+﻿using System;
 using Akamai.Utils;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;

--- a/EdgeGridAuthTest/HttpWebRequestTest.cs
+++ b/EdgeGridAuthTest/HttpWebRequestTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Akamai Technologies http://developer.akamai.com.
+﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Author: colinb@akamai.com  (Colin Bendell)
 //
 
 using System;

--- a/EdgeGridAuthTest/HttpWebRequestTest.cs
+++ b/EdgeGridAuthTest/HttpWebRequestTest.cs
@@ -1,20 +1,4 @@
-﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-//
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/EdgeGridAuthTest/Properties/AssemblyInfo.cs
+++ b/EdgeGridAuthTest/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("EdgeGridTest")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyCopyright("Copyright ©  2024")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/EdgeGridAuthTest/UtilsTest.cs
+++ b/EdgeGridAuthTest/UtilsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Akamai Technologies http://developer.akamai.com.
+﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
 //
 // Licensed under the Apache License, KitVersion 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Author: colinb@akamai.com  (Colin Bendell)
 //
 
 using System;

--- a/EdgeGridAuthTest/UtilsTest.cs
+++ b/EdgeGridAuthTest/UtilsTest.cs
@@ -1,20 +1,4 @@
-﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
-//
-// Licensed under the Apache License, KitVersion 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-//
-
-using System;
+﻿using System;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Text;

--- a/LICENSE
+++ b/LICENSE
@@ -189,7 +189,7 @@ APPENDIX: How to apply the Apache License to your work.
 Copyright 2024 Akamai Technologies, Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
+you may not use these files except in compliance with the License.
 You may obtain a copy of the License at
 
    http://www.apache.org/licenses/LICENSE-2.0

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
   same "printed page" as the copyright notice for easier
   identification within third-party archives.
 
-Copyright {yyyy} {name of copyright owner}
+Copyright 2024 Akamai Technologies, Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/OpenAPI/OpenAPI.cs
+++ b/OpenAPI/OpenAPI.cs
@@ -184,7 +184,7 @@ Where:
     -H header-line  Http Header 'Name: value'
     -X method       force HTTP PUT,POST,DELETE 
     -T content-type the HTTP content type (default = application/json)
-    url             fully qualified api url such as https://akab-1234.luna.akamaiapis.net/diagnostic-tools/v1/locations       
+    url             fully qualified api url such as https://{your-host}.luna.akamaiapis.net/identity-management/v3/user-profile       
 
 ");
         }

--- a/OpenAPI/OpenAPI.cs
+++ b/OpenAPI/OpenAPI.cs
@@ -1,20 +1,4 @@
-﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
-//
-// Licensed under the Apache License, KitVersion 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-//
-
-using Akamai.EdgeGrid.Auth;
+﻿using Akamai.EdgeGrid.Auth;
 using Akamai.Utils;
 using System;
 using System.Collections.Generic;

--- a/OpenAPI/OpenAPI.cs
+++ b/OpenAPI/OpenAPI.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Akamai Technologies http://developer.akamai.com.
+﻿// Copyright 2024 Akamai Technologies http://developer.akamai.com.
 //
 // Licensed under the Apache License, KitVersion 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Author: colinb@akamai.com  (Colin Bendell)
 //
 
 using Akamai.EdgeGrid.Auth;
@@ -31,8 +30,7 @@ namespace Akamai.EdgeGrid
     /// Command Line sample application to demonstrate the utilization of the {Open} APIs. 
     /// This can be used for both command line invocation or reference on how to leverage the 
     /// Api. All supported commands are implemented in this sample for convience.
-    /// 
-    /// Author: colinb@akamai.com  (Colin Bendell)
+    ///
     /// </summary>
     class OpenAPI
     {

--- a/OpenAPI/Properties/AssemblyInfo.cs
+++ b/OpenAPI/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("OpenAPI")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyCopyright("Copyright ©  2024")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,52 @@
-# EdgeGridSigner (for .NET/c#)
+# EdgeGrid for .NET/C#
 
-This library assists in the interaction with Akamai's {Open} API found at http://developer.akamai.com. 
-The API Spec can be found at: https://developer.akamai.com/api
+This library implements an Authentication handler for the Akamai EdgeGrid Authentication scheme in .NET/C#.
+
+You can find all Akamai APIs at https://techdocs.akamai.com/home/page/apis.
 
 ## Project organization
-* /EdgeGridAuth - core auth signere project
-* /EdgeGridAuthTest - MSTest unit tests
-* /OpenAPI - generic openapi.exe tool to demonstrate using the signer 
-* /Akamai.EdgeGrid.Auth.sln - root VisualStudio solution
+
+| Folder | Description|
+| -------- | --------- |
+| `/EdgeGridAuth` | The core auth signer project. |
+| `/EdgeGridAuthTest` | The MSTest unit tests. |
+| `/OpenAPI` | The generic `openapi.exe` tool to demonstrate using the signer. |
+| `/Akamai.EdgeGrid.Auth.sln` | The root Visual Studio solution. |
 
 ## Install
-* Open the Akamai.EdgeGrid.Auth.sln in Visual Studio; Rebuild All
-* OR ```MSBuild.exe Akamai.EdgeGrid.Auth.sln /t:rebuild```
-* Copy the Akamai.EdgeGrid.Auth.dll to your application or solution. 
 
-## Getting Started
-* Create an instance of the `EdgeGridV1Signer` and call either Sign (if you are managing the http communication yourself
-* or call Execute() to utilize built in safety checks
+1. Open `Akamai.EdgeGrid.Auth.sln` in Visual Studio and rebuild all or run `MSBuild.exe Akamai.EdgeGrid.Auth.sln /t:rebuild`.
 
-For example:
-```
+2. Copy `Akamai.EdgeGrid.Auth.sln` to your application or solution.
+
+## Authentication
+
+We provide authentication credentials through an API client. Requests to the API are signed with a timestamp and are executed immediately.
+
+1. [Create authentication credentials](https://techdocs.akamai.com/developer/docs/set-up-authentication-credentials).
+   
+2. Place your credentials in an EdgeGrid resource file, `.edgerc`, under a heading of `[default]` at your local home directory or the home directory of a web-server user.
+
+    ```
+    [default]
+    client_secret = C113nt53KR3TN6N90yVuAgICxIRwsObLi0E67/N8eRN=
+    host = akab-h05tnam3wl42son7nktnlnnx-kbob3i3v.luna.akamaiapis.net
+    access_token = akab-acc35t0k3nodujqunph3w7hzp7-gtm6ij
+    client_token = akab-c113ntt0k3n4qtari252bfxxbsl-yvsdj
+    ```
+
+## Use
+
+To use the library, create an instance of the `EdgeGridV1Signer` and call either `Sign()` (if you're managing the HTTP communication yourself) or `Execute()` to use the built-in safety checks.
+
+Provide details of your credentials from your local `.edgerc` resource file and pass them to the `ClientCredential()` method.
+
+```csharp
 using Akamai.EdgeGrid.Auth;
+
+string clientToken = "akab-c113ntt0k3n4qtari252bfxxbsl-yvsdj";
+string accessToken = "akab-acc35t0k3nodujqunph3w7hzp7-gtm6ij";
+string secret = "C113nt53KR3TN6N90yVuAgICxIRwsObLi0E67/N8eRN=";
 
 var signer = new EdgeGridV1Signer();
 var credential = new ClientCredential(clientToken, accessToken, secret);
@@ -29,25 +55,47 @@ var credential = new ClientCredential(clientToken, accessToken, secret);
 signer.Sign(httpRequest, credential);
 ```
 
-alternatively, you can use the execute() method to manage the connection and perform verification checks
-```
+Alternatively, you can use the `Execute()` method to manage the connection and perform verification checks.
+
+```csharp
 using Akamai.EdgeGrid.Auth;
 
+string clientToken = "akab-c113ntt0k3n4qtari252bfxxbsl-yvsdj";
+string accessToken = "akab-acc35t0k3nodujqunph3w7hzp7-gtm6ij";
+string secret = "C113nt53KR3TN6N90yVuAgICxIRwsObLi0E67/N8eRN=";
+
 var signer = new EdgeGridV1Signer();
-var credential = new ClientCredential(clientToken, accessToken, secret); 
+var credential = new ClientCredential(clientToken, accessToken, secret);
 
 //TODO: create httpRequest via WebRequest.Create(uri);
 signer.Execute(httpRequest, credential);
 ```
 
-
 ## Sample application (openapi.exe)
-* A sample application has been created that can take command line parameters.
+
+A sample application is available. It takes command line parameters.
 
 ```openapi.exe
--a akab-access1234
--c akab-client1234 
--s secret1234
-https://akab-url123.luna.akamaiapis.net/diagnostic-tools/v1/locations
+-a akab-acc35t0k3nodujqunph3w7hzp7-gtm6ij
+-c akab-c113ntt0k3n4qtari252bfxxbsl-yvsdj
+-s C113nt53KR3TN6N90yVuAgICxIRwsObLi0E67/N8eRN=
+https://akab-h05tnam3wl42son7nktnlnnx-kbob3i3v.luna.akamaiapis.net/identity-management/v3/user-profile
 ```
 
+## Reporting issues
+
+To report an issue or make a suggestion, create a new [GitHub issue](https://github.com/akamai/AkamaiOPEN-edgegrid-C-Sharp/issues).
+
+## License
+
+Copyright 2024 Akamai Technologies, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To report an issue or make a suggestion, create a new [GitHub issue](https://git
 Copyright 2024 Akamai Technologies, Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
+you may not use these files except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
 
 Unless required by applicable law or agreed to in writing, software


### PR DESCRIPTION
This is to update readme with more clear information. The credentials added to the code samples are abstract.
The code sample on readme suggests using the WebRequest.Create() method which according to the MS doc https://learn.microsoft.com/en-us/dotnet/api/system.net.webrequest.create?view=net-8.0 is an obsolete method. Maybe it would be worth adding support for HttpClient and how to include it in the code sample?